### PR TITLE
Add psql CLI to Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,7 @@ WORKDIR /app
 RUN ./gradlew --no-daemon linkReleaseExecutableNative
 
 FROM debian:buster-slim
+RUN apt-get update && apt-get install -y postgresql-client
 WORKDIR /app
 COPY --from=build_binary /app/build/bin/native/releaseExecutable/parse-congress-info.kexe ./
 ENV PATH "/app:$PATH"


### PR DESCRIPTION
We need the `psql` cli to be present within this Docker image so we can interact with a database in our CI pipelines elsehwhere. 