### PR TITLE
Stop using `Clock` to find current term

### DIFF
--- a/src/nativeMain/kotlin/org/climatechangemakers/parsecongress/ClimateChangemakersMemberOfCongress.kt
+++ b/src/nativeMain/kotlin/org/climatechangemakers/parsecongress/ClimateChangemakersMemberOfCongress.kt
@@ -1,6 +1,5 @@
 package org.climatechangemakers.parsecongress
 
-import kotlinx.datetime.Clock
 import kotlinx.datetime.LocalDate
 import kotlinx.serialization.Serializable
 
@@ -23,13 +22,11 @@ fun combineCurrentLegislators(
   currentLegislators: List<UnitedStatesMemberOfCongress>,
   activeScwcOffices: Map<String, String>,
   twitterAccounts: Map<String, String>,
-  clock: Clock,
 ): List<ClimateChangemakersMemberOfCongress> = currentLegislators.map { legislator ->
   combineLegislator(
     legislator = legislator,
     scwcOfficeCode = activeScwcOffices[legislator.id.bioguide],
     twitterAccount = twitterAccounts[legislator.id.bioguide],
-    clock,
   )
 }
 
@@ -37,9 +34,8 @@ private fun combineLegislator(
   legislator: UnitedStatesMemberOfCongress,
   scwcOfficeCode: String?,
   twitterAccount: String?,
-  clock: Clock,
 ): ClimateChangemakersMemberOfCongress {
-  val current = legislator.terms.current(clock)
+  val current = legislator.terms.mostRecent()
   return ClimateChangemakersMemberOfCongress(
     bioguideId = legislator.id.bioguide,
     fullName = legislator.name.officialFullname,

--- a/src/nativeMain/kotlin/org/climatechangemakers/parsecongress/Main.kt
+++ b/src/nativeMain/kotlin/org/climatechangemakers/parsecongress/Main.kt
@@ -7,10 +7,7 @@ import com.github.ajalt.clikt.parameters.groups.groupChoice
 import com.github.ajalt.clikt.parameters.groups.required
 import com.github.ajalt.clikt.parameters.options.option
 import com.github.ajalt.clikt.parameters.options.required
-import kotlinx.datetime.Clock
-import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
-import okio.BufferedSink
 import okio.Path
 import org.climatechangemakers.parsecongress.extensions.filterNotNullValues
 import org.climatechangemakers.parsecongress.extensions.path
@@ -73,7 +70,7 @@ class Parse : CliktCommand() {
       valueTransform = { it.social.twitter },
     ).filterNotNullValues()
 
-    combineCurrentLegislators(currentLegislators, activeScwcOffices, legislatorTwitterAccounts, Clock.System)
+    combineCurrentLegislators(currentLegislators, activeScwcOffices, legislatorTwitterAccounts)
       .let(::dumpToSql)
       .run(outputFilePath::writeContents)
   }

--- a/src/nativeMain/kotlin/org/climatechangemakers/parsecongress/ParseUnitedStatesMemberOfCongress.kt
+++ b/src/nativeMain/kotlin/org/climatechangemakers/parsecongress/ParseUnitedStatesMemberOfCongress.kt
@@ -29,6 +29,10 @@ fun List<UnitedStatesTermInfo>.current(clock: Clock): UnitedStatesTermInfo {
   }
 }
 
+fun List<UnitedStatesTermInfo>.mostRecent(): UnitedStatesTermInfo = checkNotNull(
+  maxByOrNull { term -> term.end }
+) { "Terms $this had no max." }
+
 @Serializable class UnitedStatesIdentifiers(
   val bioguide: String,
 )

--- a/src/nativeTest/kotlin/org/climatechangemakers/parsecongress/CombineCurrentLegislatorsTest.kt
+++ b/src/nativeTest/kotlin/org/climatechangemakers/parsecongress/CombineCurrentLegislatorsTest.kt
@@ -1,17 +1,10 @@
 package org.climatechangemakers.parsecongress
 
-import kotlinx.datetime.Clock
-import kotlinx.datetime.Instant
 import kotlinx.datetime.LocalDate
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
 class CombineCurrentLegislatorsTest {
-
-  private val fakeClock = object : Clock {
-    // April 27, 2022
-    override fun now() = Instant.fromEpochSeconds(epochSeconds = 1651078162L)
-  }
 
   private val activeScwcOffices = mapOf(
     "P000145" to "SCA03",
@@ -50,7 +43,6 @@ class CombineCurrentLegislatorsTest {
       currentLegislators = listOf(unitedStatesMemberOfCongress),
       activeScwcOffices = activeScwcOffices,
       twitterAccounts = legislatorTwitterAccounts,
-      fakeClock,
     )
 
     assertEquals(
@@ -84,7 +76,6 @@ class CombineCurrentLegislatorsTest {
       currentLegislators = listOf(unitedStatesMemberOfCongress),
       activeScwcOffices = activeScwcOffices,
       twitterAccounts = legislatorTwitterAccounts,
-      fakeClock,
     )
 
     assertEquals(
@@ -118,7 +109,6 @@ class CombineCurrentLegislatorsTest {
       currentLegislators = listOf(unitedStatesMemberOfCongress),
       activeScwcOffices = activeScwcOffices,
       twitterAccounts = legislatorTwitterAccounts,
-      fakeClock,
     )
 
     assertEquals(
@@ -152,12 +142,53 @@ class CombineCurrentLegislatorsTest {
       currentLegislators = listOf(unitedStatesMemberOfCongress),
       activeScwcOffices = activeScwcOffices,
       twitterAccounts = legislatorTwitterAccounts,
-      fakeClock,
     )
 
     assertEquals(
       expected = "HAQ00",
       actual = climateChangemakersMemberOfCongress.first().cwcOfficeCode,
+    )
+  }
+
+  @Test fun `combining gets correct term`() {
+    val unitedStatesMemberOfCongress = UnitedStatesMemberOfCongress(
+      id = UnitedStatesIdentifiers(bioguide = "M001200"),
+      name = UnitedStatesNameInfo(
+        firstName = "Donald",
+        lastName = "McEachin",
+        officialFullname = "A. Donald McEachin",
+      ),
+      terms = listOf(
+        UnitedStatesTermInfo(
+          representativeType = "rep",
+          state = "AS",
+          district = 0,
+          party = "Democrat",
+          phone = "867.5309",
+          start = LocalDate(year = 2020, monthNumber = 1, dayOfMonth = 1),
+          end = LocalDate(year = 2024, monthNumber = 1, dayOfMonth = 1)
+        ),
+        UnitedStatesTermInfo(
+          representativeType = "rep",
+          state = "AS",
+          district = 0,
+          party = "Democrat",
+          phone = "867.5309",
+          start = LocalDate(year = 2016, monthNumber = 1, dayOfMonth = 1),
+          end = LocalDate(year = 2020, monthNumber = 1, dayOfMonth = 1)
+        ),
+      )
+    )
+
+    val climateChangemakersMemberOfCongress = combineCurrentLegislators(
+      currentLegislators = listOf(unitedStatesMemberOfCongress),
+      activeScwcOffices = activeScwcOffices,
+      twitterAccounts = legislatorTwitterAccounts,
+    )
+
+    assertEquals(
+      expected = LocalDate(year = 2024, dayOfMonth = 1, monthNumber = 1),
+      actual = climateChangemakersMemberOfCongress.first().termEndDate,
     )
   }
 }

--- a/src/nativeTest/kotlin/org/climatechangemakers/parsecongress/DumpToSqlTest.kt
+++ b/src/nativeTest/kotlin/org/climatechangemakers/parsecongress/DumpToSqlTest.kt
@@ -1,18 +1,10 @@
 package org.climatechangemakers.parsecongress
 
-import kotlinx.datetime.Clock
-import kotlinx.datetime.Instant
-import kotlinx.datetime.TimeZone
-import kotlinx.datetime.todayAt
+import kotlinx.datetime.LocalDate
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
 class DumpToSqlTest {
-
-  private val fakeClock = object : Clock {
-    // April 27, 2022
-    override fun now() = Instant.fromEpochSeconds(epochSeconds = 1651078162L)
-  }
 
   @Test fun `dumping a single member of congress produces expected result`() {
     val members = listOf(
@@ -28,7 +20,7 @@ class DumpToSqlTest {
         dcPhoneNumber = "555.555.5555",
         twitterHandle = null,
         cwcOfficeCode = null,
-        termEndDate = fakeClock.todayAt(TimeZone.UTC),
+        termEndDate = LocalDate(year = 2022, monthNumber = 4, dayOfMonth = 27),
       )
     )
 
@@ -45,9 +37,6 @@ class DumpToSqlTest {
   }
 
   @Test fun `date is padded correctly`() {
-    val clock = object : Clock {
-      override fun now(): Instant = Instant.fromEpochSeconds(1649350162L)
-    }
     val members = listOf(
       ClimateChangemakersMemberOfCongress(
         bioguideId = "C000001",
@@ -61,7 +50,7 @@ class DumpToSqlTest {
         dcPhoneNumber = "555.555.5555",
         twitterHandle = null,
         cwcOfficeCode = null,
-        termEndDate = clock.todayAt(TimeZone.UTC),
+        termEndDate = LocalDate(year = 2022, monthNumber = 4, dayOfMonth = 7),
       )
     )
 
@@ -91,7 +80,7 @@ class DumpToSqlTest {
         dcPhoneNumber = "555.555.5555",
         twitterHandle = null,
         cwcOfficeCode = null,
-        termEndDate = fakeClock.todayAt(TimeZone.UTC),
+        termEndDate = LocalDate(year = 2022, monthNumber = 4, dayOfMonth = 27),
       )
     )
 
@@ -121,7 +110,7 @@ class DumpToSqlTest {
         dcPhoneNumber = "555.555.5555",
         twitterHandle = null,
         cwcOfficeCode = null,
-        termEndDate = fakeClock.todayAt(TimeZone.UTC),
+        termEndDate = LocalDate(year = 2022, monthNumber = 4, dayOfMonth = 27),
       ),
       ClimateChangemakersMemberOfCongress(
         bioguideId = "C000002",
@@ -135,7 +124,7 @@ class DumpToSqlTest {
         dcPhoneNumber = "555.555.5556",
         twitterHandle = null,
         cwcOfficeCode = null,
-        termEndDate = fakeClock.todayAt(TimeZone.UTC),
+        termEndDate = LocalDate(year = 2022, monthNumber = 4, dayOfMonth = 27),
       )
     )
 
@@ -173,7 +162,7 @@ class DumpToSqlTest {
     )
   }
 
-  @Test fun `dumping multiple distrcit offices produces expected result`() {
+  @Test fun `dumping multiple district offices produces expected result`() {
     val offices = listOf(
       ClimateChangemakersDistrictOffice(
         bioguide = "C000002",

--- a/src/nativeTest/kotlin/org/climatechangemakers/parsecongress/ParseUnitedStatesMemberOfCongressTest.kt
+++ b/src/nativeTest/kotlin/org/climatechangemakers/parsecongress/ParseUnitedStatesMemberOfCongressTest.kt
@@ -1,0 +1,45 @@
+package org.climatechangemakers.parsecongress
+
+import kotlinx.datetime.LocalDate
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class ParseUnitedStatesMemberOfCongressTest {
+
+  @Test fun `gets most recent term`() {
+    val terms = listOf(
+      UnitedStatesTermInfo(
+        representativeType = "sen",
+        state = "VA",
+        party = "Democrat",
+        district = null,
+        phone = null,
+        start = LocalDate(year = 2020, dayOfMonth = 1, monthNumber = 1),
+        end = LocalDate(year = 2024, dayOfMonth = 1, monthNumber = 1),
+      ),
+      UnitedStatesTermInfo(
+        representativeType = "sen",
+        state = "VA",
+        party = "Democrat",
+        district = null,
+        phone = null,
+        start = LocalDate(year = 2016, dayOfMonth = 1, monthNumber = 1),
+        end = LocalDate(year = 2020, dayOfMonth = 1, monthNumber = 1),
+      ),
+      UnitedStatesTermInfo(
+        representativeType = "sen",
+        state = "VA",
+        party = "Democrat",
+        district = null,
+        phone = null,
+        start = LocalDate(year = 2012, dayOfMonth = 1, monthNumber = 1),
+        end = LocalDate(year = 2016, dayOfMonth = 1, monthNumber = 1),
+      ),
+    )
+
+    assertEquals(
+      expected = LocalDate(year = 2024, dayOfMonth = 1, monthNumber = 1),
+      actual = terms.mostRecent().end,
+    )
+  }
+}


### PR DESCRIPTION
To resolve #6, we need to find the current term without caring what
today's date is. It was a fragile and bad implementation anyway.

This commit sorts all of the terms for a given Member of Congress. The
`mostRecent` term is considered to be the current term for active
legislators.

I performed a text diff between `trunk` and this commit for program
output. They were identical.

References #6
