### PR TITLE
Add duplicate Member of Congress check

### DIFF
--- a/src/nativeMain/kotlin/org/climatechangemakers/parsecongress/ClimateChangemakersMemberOfCongress.kt
+++ b/src/nativeMain/kotlin/org/climatechangemakers/parsecongress/ClimateChangemakersMemberOfCongress.kt
@@ -1,5 +1,6 @@
 package org.climatechangemakers.parsecongress
 
+import com.github.ajalt.clikt.core.PrintMessage
 import kotlinx.datetime.LocalDate
 import kotlinx.serialization.Serializable
 
@@ -19,6 +20,47 @@ import kotlinx.serialization.Serializable
 )
 
 fun combineLegislators(
+  current: List<UnitedStatesMemberOfCongress>,
+  historical: List<UnitedStatesMemberOfCongress>,
+  activeScwcOffices: Map<String, String>,
+  twitterAccounts: Map<String, String>,
+  today: LocalDate,
+): List<ClimateChangemakersMemberOfCongress> {
+  val historicalLegislators: List<UnitedStatesMemberOfCongress> = historical.filter { member ->
+    val term = member.terms.mostRecent()
+    // Some historical Members of Congress don't have a party. Omit them.
+    term.party != null &&
+        // Some historical Members of Congress don't have a DC phone. Omit them.
+        term.phone != null &&
+        // Come historical Members of Congress don't have an official full name. Omit them.
+        member.name.officialFullname != null
+  }
+
+  val allLegislators = current + historicalLegislators
+  val duplicateLegislators: List<String> = allLegislators
+    .groupBy { member -> member.id.bioguide }
+    .filter { (_, members) -> members.count() > 1 }
+    .map { (bioguide, _) -> bioguide }
+
+  if (duplicateLegislators.isNotEmpty()) {
+    throw PrintMessage(
+      error = true,
+      message = """
+          Found duplicate Members of Congress: $duplicateLegislators.
+          Did you forget to update both current and historical legislator files?
+        """.trimIndent()
+    )
+  }
+
+  return combineLegislators(
+    legislators = allLegislators,
+    activeScwcOffices  = activeScwcOffices,
+    twitterAccounts = twitterAccounts,
+    today = today,
+  )
+}
+
+private fun combineLegislators(
   legislators: List<UnitedStatesMemberOfCongress>,
   activeScwcOffices: Map<String, String>,
   twitterAccounts: Map<String, String>,

--- a/src/nativeMain/kotlin/org/climatechangemakers/parsecongress/Main.kt
+++ b/src/nativeMain/kotlin/org/climatechangemakers/parsecongress/Main.kt
@@ -64,15 +64,7 @@ class Parse : CliktCommand() {
     val historicalLegislators: List<UnitedStatesMemberOfCongress> = parseUnitedStatesMemberOfCongressFile(
       group.historicalLegislatorsPath.readContents(),
       json,
-    ).filter { member ->
-      val term = member.terms.mostRecent()
-      // Some historical Members of Congress don't have a party. Omit them.
-      term.party != null &&
-          // Some historical Members of Congress don't have a DC phone. Omit them.
-          term.phone != null &&
-          // Come historical Members of Congress don't have an official full name. Omit them.
-          member.name.officialFullname != null
-    }
+    )
 
     val activeScwcOffices: Map<String, String> = parseActiveCwcOffices(
       group.cwcOfficeCodesPath.readContents(),
@@ -88,7 +80,8 @@ class Parse : CliktCommand() {
     ).filterNotNullValues()
 
     combineLegislators(
-      legislators = currentLegislators + historicalLegislators,
+      historical = historicalLegislators,
+      current = currentLegislators,
       activeScwcOffices = activeScwcOffices,
       twitterAccounts = legislatorTwitterAccounts,
       today = Clock.System.todayAt(TimeZone.UTC),

--- a/src/nativeMain/kotlin/org/climatechangemakers/parsecongress/ParseCWCActiveOffices.kt
+++ b/src/nativeMain/kotlin/org/climatechangemakers/parsecongress/ParseCWCActiveOffices.kt
@@ -3,13 +3,16 @@ package org.climatechangemakers.parsecongress
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.Serializable
-import kotlinx.serialization.decodeFromString
+import kotlinx.serialization.builtins.ListSerializer
 
 fun parseActiveCwcOffices(
   rawJson: String,
   json: Json,
 ): List<ActiveOffice> {
-  return json.decodeFromString(rawJson)
+  return json.decodeFromString(
+    deserializer = ListSerializer(ActiveOffice.serializer()),
+    string = rawJson,
+  )
 }
 
 private val bioguideRegex = Regex("""[A-Z][0-9]+""")

--- a/src/nativeMain/kotlin/org/climatechangemakers/parsecongress/ParseDistrictOffice.kt
+++ b/src/nativeMain/kotlin/org/climatechangemakers/parsecongress/ParseDistrictOffice.kt
@@ -1,7 +1,7 @@
 package org.climatechangemakers.parsecongress
 
 import kotlinx.serialization.Serializable
-import kotlinx.serialization.decodeFromString
+import kotlinx.serialization.builtins.ListSerializer
 import kotlinx.serialization.json.Json
 import okio.BufferedSource
 import okio.FileSystem
@@ -27,7 +27,10 @@ class ClimateChangemakersDistrictOffice(
 
 fun readDistrictOfficeFile(path: Path, json: Json): List<ClimateChangemakersDistrictOffice> {
   val jsonString = FileSystem.SYSTEM.read(path, BufferedSource::readUtf8)
-  return json.decodeFromString<List<UnitedStatesMemberOfCongressDistrictOffices>>(jsonString).flatMap { member ->
+  return json.decodeFromString(
+    deserializer = ListSerializer(UnitedStatesMemberOfCongressDistrictOffices.serializer()),
+    string = jsonString,
+  ).flatMap { member ->
     member.offices.asSequence().filter { office ->
       // There's no use persising district offices that don't have phone numbers; it's the only data point we care about.
       office.phone != null

--- a/src/nativeMain/kotlin/org/climatechangemakers/parsecongress/ParseSocialMedia.kt
+++ b/src/nativeMain/kotlin/org/climatechangemakers/parsecongress/ParseSocialMedia.kt
@@ -2,13 +2,16 @@ package org.climatechangemakers.parsecongress
 
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.Serializable
-import kotlinx.serialization.decodeFromString
+import kotlinx.serialization.builtins.ListSerializer
 
 fun parseUnitedStatedMemberOfCongressSocialMedia(
   rawJson: String,
   json: Json,
 ): List<UnitedStatesMemberOfCongressSocial> {
-  return json.decodeFromString(rawJson)
+  return json.decodeFromString(
+    deserializer = ListSerializer(UnitedStatesMemberOfCongressSocial.serializer()),
+    string = rawJson,
+  )
 }
 
 @Serializable class UnitedStatesMemberOfCongressSocial(

--- a/src/nativeMain/kotlin/org/climatechangemakers/parsecongress/ParseUnitedStatesMemberOfCongress.kt
+++ b/src/nativeMain/kotlin/org/climatechangemakers/parsecongress/ParseUnitedStatesMemberOfCongress.kt
@@ -3,14 +3,17 @@ package org.climatechangemakers.parsecongress
 import kotlinx.datetime.LocalDate
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
-import kotlinx.serialization.decodeFromString
+import kotlinx.serialization.builtins.ListSerializer
 import kotlinx.serialization.json.Json
 
 fun parseUnitedStatesMemberOfCongressFile(
   rawJson: String,
   json: Json,
 ): List<UnitedStatesMemberOfCongress> {
-  return json.decodeFromString(rawJson)
+  return json.decodeFromString(
+    deserializer = ListSerializer(UnitedStatesMemberOfCongress.serializer()),
+    string = rawJson
+  )
 }
 
 @Serializable class UnitedStatesMemberOfCongress(

--- a/src/nativeTest/kotlin/org/climatechangemakers/parsecongress/CombineCurrentLegislatorsTest.kt
+++ b/src/nativeTest/kotlin/org/climatechangemakers/parsecongress/CombineCurrentLegislatorsTest.kt
@@ -1,9 +1,12 @@
 package org.climatechangemakers.parsecongress
 
+import com.github.ajalt.clikt.core.PrintMessage
 import kotlinx.datetime.LocalDate
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
 import kotlin.test.assertNull
+import kotlin.test.assertTrue
 
 class CombineCurrentLegislatorsTest {
 
@@ -41,7 +44,8 @@ class CombineCurrentLegislatorsTest {
     )
 
     val climateChangemakersMemberOfCongress = combineLegislators(
-      legislators = listOf(unitedStatesMemberOfCongress),
+      current = listOf(unitedStatesMemberOfCongress),
+      historical = emptyList(),
       activeScwcOffices = activeScwcOffices,
       twitterAccounts = legislatorTwitterAccounts,
       today = LocalDate(year = 2022, monthNumber = 4, dayOfMonth = 27),
@@ -75,7 +79,8 @@ class CombineCurrentLegislatorsTest {
     )
 
     val climateChangemakersMemberOfCongress = combineLegislators(
-      legislators = listOf(unitedStatesMemberOfCongress),
+      current = listOf(unitedStatesMemberOfCongress),
+      historical = emptyList(),
       activeScwcOffices = activeScwcOffices,
       twitterAccounts = legislatorTwitterAccounts,
       today = LocalDate(year = 2022, monthNumber = 4, dayOfMonth = 27),
@@ -109,7 +114,8 @@ class CombineCurrentLegislatorsTest {
     )
 
     val climateChangemakersMemberOfCongress = combineLegislators(
-      legislators = listOf(unitedStatesMemberOfCongress),
+      current = listOf(unitedStatesMemberOfCongress),
+      historical = emptyList(),
       activeScwcOffices = activeScwcOffices,
       twitterAccounts = legislatorTwitterAccounts,
       today = LocalDate(year = 2022, monthNumber = 4, dayOfMonth = 27),
@@ -143,7 +149,8 @@ class CombineCurrentLegislatorsTest {
     )
 
     val climateChangemakersMemberOfCongress = combineLegislators(
-      legislators = listOf(unitedStatesMemberOfCongress),
+      current = listOf(unitedStatesMemberOfCongress),
+      historical = emptyList(),
       activeScwcOffices = activeScwcOffices,
       twitterAccounts = legislatorTwitterAccounts,
       today = LocalDate(year = 2022, monthNumber = 4, dayOfMonth = 27),
@@ -177,7 +184,8 @@ class CombineCurrentLegislatorsTest {
     )
 
     val climateChangemakersMemberOfCongress = combineLegislators(
-      legislators = listOf(unitedStatesMemberOfCongress),
+      current = listOf(unitedStatesMemberOfCongress),
+      historical = emptyList(),
       activeScwcOffices = activeScwcOffices,
       twitterAccounts = legislatorTwitterAccounts,
       today = LocalDate(year = 2022, monthNumber = 4, dayOfMonth = 27),
@@ -217,7 +225,8 @@ class CombineCurrentLegislatorsTest {
     )
 
     val climateChangemakersMemberOfCongress = combineLegislators(
-      legislators = listOf(unitedStatesMemberOfCongress),
+      current = listOf(unitedStatesMemberOfCongress),
+      historical = emptyList(),
       activeScwcOffices = activeScwcOffices,
       twitterAccounts = legislatorTwitterAccounts,
       today = LocalDate(year = 2022, monthNumber = 4, dayOfMonth = 27),
@@ -227,5 +236,133 @@ class CombineCurrentLegislatorsTest {
       expected = LocalDate(year = 2024, dayOfMonth = 1, monthNumber = 1),
       actual = climateChangemakersMemberOfCongress.first().termEndDate,
     )
+  }
+
+  @Test fun `historical legislators filters null party`() {
+    val unitedStatesMemberOfCongress = UnitedStatesMemberOfCongress(
+      id = UnitedStatesIdentifiers(bioguide = "M001200"),
+      name = UnitedStatesNameInfo(
+        firstName = "Donald",
+        lastName = "McEachin",
+        officialFullname = "A. Donald McEachin",
+      ),
+      terms = listOf(
+        UnitedStatesTermInfo(
+          representativeType = "rep",
+          state = "AS",
+          district = 0,
+          party = null,
+          phone = "867.5309",
+          start = LocalDate(year = 2020, monthNumber = 1, dayOfMonth = 1),
+          end = LocalDate(year = 2024, monthNumber = 1, dayOfMonth = 1)
+        ),
+      )
+    )
+
+    val climateChangemakersMemberOfCongress = combineLegislators(
+      historical = listOf(unitedStatesMemberOfCongress),
+      current = emptyList(),
+      activeScwcOffices = activeScwcOffices,
+      twitterAccounts = legislatorTwitterAccounts,
+      today = LocalDate(year = 2022, monthNumber = 4, dayOfMonth = 27),
+    )
+
+    assertTrue(climateChangemakersMemberOfCongress.isEmpty())
+  }
+
+  @Test fun `historical legislators filters null DC phone`() {
+    val unitedStatesMemberOfCongress = UnitedStatesMemberOfCongress(
+      id = UnitedStatesIdentifiers(bioguide = "M001200"),
+      name = UnitedStatesNameInfo(
+        firstName = "Donald",
+        lastName = "McEachin",
+        officialFullname = "A. Donald McEachin",
+      ),
+      terms = listOf(
+        UnitedStatesTermInfo(
+          representativeType = "rep",
+          state = "AS",
+          district = 0,
+          party = "Democrat",
+          phone = null,
+          start = LocalDate(year = 2020, monthNumber = 1, dayOfMonth = 1),
+          end = LocalDate(year = 2024, monthNumber = 1, dayOfMonth = 1)
+        ),
+      )
+    )
+
+    val climateChangemakersMemberOfCongress = combineLegislators(
+      historical = listOf(unitedStatesMemberOfCongress),
+      current = emptyList(),
+      activeScwcOffices = activeScwcOffices,
+      twitterAccounts = legislatorTwitterAccounts,
+      today = LocalDate(year = 2022, monthNumber = 4, dayOfMonth = 27),
+    )
+
+    assertTrue(climateChangemakersMemberOfCongress.isEmpty())
+  }
+
+  @Test fun `historical legislators filters null official full name`() {
+    val unitedStatesMemberOfCongress = UnitedStatesMemberOfCongress(
+      id = UnitedStatesIdentifiers(bioguide = "M001200"),
+      name = UnitedStatesNameInfo(
+        firstName = "Donald",
+        lastName = "McEachin",
+        officialFullname = null,
+      ),
+      terms = listOf(
+        UnitedStatesTermInfo(
+          representativeType = "rep",
+          state = "AS",
+          district = 0,
+          party = "Democrat",
+          phone = "867.5309",
+          start = LocalDate(year = 2020, monthNumber = 1, dayOfMonth = 1),
+          end = LocalDate(year = 2024, monthNumber = 1, dayOfMonth = 1)
+        ),
+      )
+    )
+
+    val climateChangemakersMemberOfCongress = combineLegislators(
+      historical = listOf(unitedStatesMemberOfCongress),
+      current = emptyList(),
+      activeScwcOffices = activeScwcOffices,
+      twitterAccounts = legislatorTwitterAccounts,
+      today = LocalDate(year = 2022, monthNumber = 4, dayOfMonth = 27),
+    )
+
+    assertTrue(climateChangemakersMemberOfCongress.isEmpty())
+  }
+
+  @Test fun `duplicate legislators fails`() {
+    val unitedStatesMemberOfCongress = UnitedStatesMemberOfCongress(
+      id = UnitedStatesIdentifiers(bioguide = "M001200"),
+      name = UnitedStatesNameInfo(
+        firstName = "Donald",
+        lastName = "McEachin",
+        officialFullname = "A. Donald McEachin",
+      ),
+      terms = listOf(
+        UnitedStatesTermInfo(
+          representativeType = "rep",
+          state = "AS",
+          district = 0,
+          party = "Democrat",
+          phone = "867.5309",
+          start = LocalDate(year = 2020, monthNumber = 1, dayOfMonth = 1),
+          end = LocalDate(year = 2024, monthNumber = 1, dayOfMonth = 1)
+        ),
+      )
+    )
+
+    assertFailsWith<PrintMessage> {
+      combineLegislators(
+        historical = listOf(unitedStatesMemberOfCongress),
+        current = listOf(unitedStatesMemberOfCongress),
+        activeScwcOffices = activeScwcOffices,
+        twitterAccounts = legislatorTwitterAccounts,
+        today = LocalDate(year = 2022, monthNumber = 4, dayOfMonth = 27),
+      )
+    }
   }
 }


### PR DESCRIPTION
Since both the historical and current legislators files need to be in
sync, there's a possibility of some calling error. This commit adds
checks to ensure that there are no duplicated Members of Congress in the
program output.
