### PR TITLE
Generate default full name given a null source

### DIFF
--- a/src/nativeMain/kotlin/org/climatechangemakers/parsecongress/ClimateChangemakersMemberOfCongress.kt
+++ b/src/nativeMain/kotlin/org/climatechangemakers/parsecongress/ClimateChangemakersMemberOfCongress.kt
@@ -83,7 +83,7 @@ private fun combineLegislator(
   val current = legislator.terms.mostRecent()
   return ClimateChangemakersMemberOfCongress(
     bioguideId = legislator.id.bioguide,
-    fullName = checkNotNull(legislator.name.officialFullname) { "$legislator did not have an official full name." },
+    fullName = legislator.name.officialFullname ?: "${legislator.name.firstName} ${legislator.name.lastName}",
     firstName = legislator.name.firstName,
     lastName = legislator.name.lastName,
     legislativeRole = current.representativeType,


### PR DESCRIPTION
I was under the assumption when I originally wrote this code that
legislators who are currenly in office will always have an official
full name.

The most recent addition to this data, Mike Flood, disproves this
theory. This commit adds a default for currently sitting Members of
Congress.
